### PR TITLE
fix dep module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "minimatch": "~0.2.14",
     "mkdirp": "~0.3.5",
     "nedb": "~0.8.12",
-    "uglify-js": ">=2.4.0",
+    "uglify-js": "2.4.0",
     "underscore": "~1.5.2",
     "update-notifier": "~0.1.7"
   },


### PR DESCRIPTION
新版 UglifyJS 不在支持 UglifyJS.minify 方法，npm install 以后，执行 grunt 不能正确的生成文件，为了能继续使用，该 PR 将 UglifyJS 修改为精确的版本号。